### PR TITLE
Require requests >= 2.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'requests',
+        'requests >= 2.0',
         'beautifulsoup4',
         'six >= 1.4'
         ],


### PR DESCRIPTION
`Session.prepare_request` was added in [*requests 2.0.0*](https://pypi.python.org/pypi/requests#id24). So this version should be ensured in *setup.py*.

This bit me on an old system with an old version of *requests* already installed.