### PR TITLE
Handle empty "method" & "action" and submit via GET correctly

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -84,7 +84,7 @@ class Browser(object):
                 if i == 0 or "selected" in option.attrs:
                     data[name] = option.get("value", "")
 
-        if method == "get":
+        if method.lower() == "get":
             kwargs["params"] = data
         else:
             kwargs["data"] = data

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -5,7 +5,7 @@ from six import string_types
 from .form import Form
 
 
-class Browser:
+class Browser(object):
 
     def __init__(self, session=None, soup_config=None):
         self.session = session or requests.Session()

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -33,9 +33,11 @@ class Browser:
         return response
 
     def _build_request(self, form, url=None, **kwargs):
-        method = form["method"]
-        action = form["action"]
+        method = form.get("method", "get")
+        action = form.get("action")
         url = urllib.parse.urljoin(url, action)
+        if url is None:  # This happens when both `action` and `url` are None.
+            raise ValueError('no URL to submit to')
 
         # read http://www.w3.org/TR/html5/forms.html
         data = kwargs.get("data") or dict()

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -40,8 +40,8 @@ class Browser(object):
             raise ValueError('no URL to submit to')
 
         # read http://www.w3.org/TR/html5/forms.html
-        data = kwargs.get("data") or dict()
-        files = kwargs.get("files") or dict()
+        data = kwargs.pop("data", dict())
+        files = kwargs.pop("files", dict())
 
         for input in form.select("input"):
             name = input.get("name")
@@ -84,7 +84,11 @@ class Browser(object):
                 if i == 0 or "selected" in option.attrs:
                     data[name] = option.get("value", "")
 
-        return requests.Request(method, url, data=data, files=files, **kwargs)
+        if method == "get":
+            kwargs["params"] = data
+        else:
+            kwargs["data"] = data
+        return requests.Request(method, url, files=files, **kwargs)
 
     def _prepare_request(self, form, url=None, **kwargs):
         request = self._build_request(form, url, **kwargs)

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -1,4 +1,4 @@
-class Form:
+class Form(object):
 
     def __init__(self, form):
         self.form = form


### PR DESCRIPTION
This fixes the library to correctly handle the following scenarios:

- The `"method"` attribute of a form may be left unspecified, in which case it defaults to GET.
- The `"action"` method of a form may be left unspecified, in which case it should be the URL of the source document, which in this case is (assumed to be) the `url` argument to `submit`.  (If both `"action"` and `url` are undefined, raise an error.)
- When submitting form data via GET, the data should be passed to `requests` in the `params` argument, not `data`.

Also fixed a couple minor coding things.