### PR TITLE
added requests's custom adapter implementation

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -7,8 +7,13 @@ from .form import Form
 
 class Browser(object):
 
-    def __init__(self, session=None, soup_config=None):
+    def __init__(self, session=None, soup_config=None, requests_adapters=None):
         self.session = session or requests.Session()
+
+        if requests_adapters is not None:
+            for adaptee, adapter in requests_adapters.items():
+                self.session.mount(adaptee, adapter)
+
         self.soup_config = soup_config or dict()
 
     @staticmethod


### PR DESCRIPTION
This change will make us able to implement custom transport adapter, increasing possibilities of connection customization.

It's possible to pass to `Browser()` a dict containig the adaptee as key, and the adapter itself as value.
 
(see for reference: http://docs.python-requests.org/en/latest/user/advanced/#transport-adapters)