### PR TITLE
Get rid of BeautifulSoup warning

### DIFF
--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -20,7 +20,7 @@ class Browser(object):
     def add_soup(response, soup_config):
         if "text/html" in response.headers.get("Content-Type", ""):
             response.soup = bs4.BeautifulSoup(
-                response.content, **soup_config)
+                response.content, 'html.parser', **soup_config)
 
     def request(self, *args, **kwargs):
         response = self.session.request(*args, **kwargs)

--- a/mechanicalsoup/browser.py
+++ b/mechanicalsoup/browser.py
@@ -20,7 +20,7 @@ class Browser(object):
     def add_soup(response, soup_config):
         if "text/html" in response.headers.get("Content-Type", ""):
             response.soup = bs4.BeautifulSoup(
-                response.content, 'html.parser', **soup_config)
+                response.content, "html.parser", **soup_config)
 
     def request(self, *args, **kwargs):
         response = self.session.request(*args, **kwargs)


### PR DESCRIPTION
get rid of this warning,

UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.