### PR TITLE
Fix incorrect PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I was a fond user of the [Mechanize](https://github.com/jjlee/mechanize) library
 Installation
 ------
 
-[![Latest Version](https://img.shields.io/pypi/v/nine.svg)](https://pypi.python.org/pypi/MechanicalSoup/)
+[![Latest Version](https://img.shields.io/pypi/v/MechanicalSoup.svg)](https://pypi.python.org/pypi/MechanicalSoup/)
 
 From [PyPI](https://pypi.python.org/pypi/MechanicalSoup/)
 


### PR DESCRIPTION
A version of PyPI badge is incorrect.

| Before | After |
|-----|----|
| <img width="342" alt="2016-06-11 23 35 51" src="https://cloud.githubusercontent.com/assets/532251/15985579/87e37994-302d-11e6-9be2-1a4552400259.png"> | <img width="270" alt="2016-06-11 23 36 59" src="https://cloud.githubusercontent.com/assets/532251/15985580/8ebfdfa0-302d-11e6-92d3-1771ac8ea648.png"> |
