### PR TITLE
example.py: restore changes lost by bad merge

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,20 +2,21 @@
 import argparse
 import mechanicalsoup
 
-parser = argparse.ArgumentParser(description='Login to GitHub.')
+parser = argparse.ArgumentParser(description="Login to GitHub.")
 parser.add_argument("username")
 parser.add_argument("password")
 args = parser.parse_args()
 
 browser = mechanicalsoup.Browser()
 
-# request github login page. the result is a requests.Response object http://docs.python-requests.org/en/latest/user/quickstart/#response-content
+# request github login page. the result is a requests.Response object
+# http://docs.python-requests.org/en/latest/user/quickstart/#response-content
 login_page = browser.get("https://github.com/login")
 login_page.raise_for_status()  # similar to assert login_page.ok but with full status code in case of failure.
 
-# login_page.soup is a BeautifulSoup object http://www.crummy.com/software/BeautifulSoup/bs4/doc/#beautifulsoup 
+# login_page.soup is a BeautifulSoup object http://www.crummy.com/software/BeautifulSoup/bs4/doc/#beautifulsoup
 # we grab the login form
-login_form = login_page.soup.select_one('#login form')
+login_form = mechanicalsoup.Form(login_page.soup.select_one('#login form'))
 
 # specify username and password
 login_form.input({"login": args.username, "password": args.password})
@@ -24,13 +25,14 @@ login_form.input({"login": args.username, "password": args.password})
 page2 = browser.submit(login_form, login_page.url)
 
 # verify we are now logged in
-messages = page2.soup.find('div', class_='flash-messages')
+messages = page2.soup.find("div", class_="flash-messages")
 if messages:
     print(messages.text)
 assert page2.soup.select(".logout-form")
 
 print(page2.soup.title.text)
 
-# verify we remain logged in (thanks to cookies) as we browse the rest of the site
+# verify we remain logged in (thanks to cookies) as we browse the rest of
+# the site
 page3 = browser.get("https://github.com/hickford/MechanicalSoup")
 assert page3.soup.select(".logout-form")


### PR DESCRIPTION
ea5e675 (update example.py, 2015-06-30) introduced a bunch of
improvements to example.py, and most of these changes were accidentally
reverted by 4907e63 (Merge branch 'Xuefeng-Zhu-example', 2015-11-24).

In particular, the original commit introduced the creation of a
mechanicalsoup.Form() object based on a beautiful soup one, and this
change is needed for the code to work. Without this, one tries to call
method input() on a soup object instead of using the mechanicalsoup one.

Fixes #40.