### PR TITLE
New features (stateful browser, __setitem__, ...) from chamilotools

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,0 +1,40 @@
+"""Example app to login to GitHub using the StatefulBrowser class."""
+
+from __future__ import print_function
+import argparse
+import mechanicalsoup
+from getpass import getpass
+
+parser = argparse.ArgumentParser(description="Login to GitHub.")
+parser.add_argument("username")
+args = parser.parse_args()
+
+args.password = getpass("Please enter your GitHub password: ")
+
+browser = mechanicalsoup.StatefulBrowser()
+# Uncomment for a more verbose output:
+# browser.set_verbose(2)
+
+browser.open("https://github.com")
+browser.follow_link("login")
+browser.select_form('#login form')
+browser["login"] = args.username
+browser["password"] = args.password
+resp = browser.submit_selected()
+
+# Uncomment to launch a web browser on the current page:
+# browser.launch_browser()
+
+# verify we are now logged in
+page = browser.get_current_page()
+messages = page.find("div", class_="flash-messages")
+if messages:
+    print(messages.text)
+assert page.select(".logout-form")
+
+print(page.title.text)
+
+# verify we remain logged in (thanks to cookies) as we browse the rest of
+# the site
+page3 = browser.open("https://github.com/hickford/MechanicalSoup")
+assert page3.soup.select(".logout-form")

--- a/example_manual.py
+++ b/example_manual.py
@@ -1,4 +1,4 @@
-"""Example app to login to GitHub"""
+"""Example app to login to GitHub, using the plain Browser class."""
 import argparse
 import mechanicalsoup
 

--- a/example_manual.py
+++ b/example_manual.py
@@ -1,4 +1,6 @@
-"""Example app to login to GitHub, using the plain Browser class."""
+"""Example app to login to GitHub, using the plain Browser class.
+
+See example.py for an example using the more advanced StatefulBrowser."""
 import argparse
 import mechanicalsoup
 

--- a/mechanicalsoup/__init__.py
+++ b/mechanicalsoup/__init__.py
@@ -1,5 +1,6 @@
+from .utils import LinkNotFoundError
 from .browser import Browser
 from .form import Form
 from .stateful_browser import StatefulBrowser
 
-__all__ = ['Browser', 'StatefulBrowser', 'Form']
+__all__ = ['LinkNotFoundError', 'Browser', 'StatefulBrowser', 'Form']

--- a/mechanicalsoup/__init__.py
+++ b/mechanicalsoup/__init__.py
@@ -1,4 +1,5 @@
 from .browser import Browser
 from .form import Form
+from .stateful_browser import StatefulBrowser
 
-__all__ = ['Browser', 'Form']
+__all__ = ['Browser', 'StatefulBrowser', 'Form']

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -1,4 +1,5 @@
 from .utils import LinkNotFoundError
+from bs4 import BeautifulSoup
 
 
 class Form(object):
@@ -34,10 +35,19 @@ class Form(object):
             if not isinstance(value, list):
                 value = (value,)
             for choice in value:
-                i = self.form.find("input", {"name": name, "value": choice})
-                if not i:
-                    raise LinkNotFoundError("No input checkbox named " + name)
-                i["checked"] = ""
+                choice = str(choice)  # Allow for example literal numbers
+                found = False
+                for i in inputs:
+                    if i.attrs.get("value", "on") == choice:
+                        i["checked"] = ""
+                        found = True
+                        break
+                if not found:
+                    print(self.form)
+                    raise LinkNotFoundError(
+                        "No input checkbox named %s with choice %s" %
+                        (name, choice)
+                        )
 
     def textarea(self, data):
         for (name, value) in data.items():
@@ -45,6 +55,56 @@ class Form(object):
             if not t:
                 raise LinkNotFoundError("No textarea named " + name)
             t.string = value
+
+    def __setitem__(self, name, value):
+        return self.set(name, value)
+
+    def set(self, name, value, force=False):
+        input = self.form.find("input", {"name": name})
+        if input:
+            if input.attrs.get('type', 'text') in ("radio", "checkbox"):
+                if value is True:
+                    # f["foo"] = True checks the box foo
+                    input.attrs["checked"] = ""
+                else:
+                    self.check({name: value})
+            else:
+                input["value"] = value
+            return
+        textarea = self.form.find("textarea", {"name": name})
+        if textarea:
+            textarea.string = value
+            return
+        select = self.form.find("select", {"name": name})
+        if select:
+            for option in select.find_all("option"):
+                if "selected" in option.attrs:
+                    del option.attrs["selected"]
+            o = select.find("option", {"value": value})
+            o.attrs["selected"] = "selected"
+            return
+        if force:
+            self.new_control('input', name, value=value)
+            return
+        raise LinkNotFoundError()
+
+    def new_control(self, type, name, value, **kwargs):
+        old = self.form.find('input', {'name': name})
+        if old:
+            old.decompose()
+        old = self.form.find('textarea', {'name': name})
+        if old:
+            old.decompose()
+        # We don't have access to the original soup object, so we
+        # instantiate a new BeautifulSoup() to call new_tag().
+        control = BeautifulSoup().new_tag('input')
+        control['type'] = type
+        control['name'] = name
+        control['value'] = value
+        for k, v in kwargs.items():
+            control[k] = v
+        self.form.append(control)
+        return control
 
     def choose_submit(self, el):
         # In a normal web browser, when a input[type=submit] is clicked,

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -32,7 +32,9 @@ class Form(object):
             if type == "radio":
                 self.uncheck_all(name)
 
-            if not isinstance(value, list):
+            # Accept individual values (int, str)
+            # We just wrap them in a 1-value tuple.
+            if not isinstance(value, list) and not isinstance(value, tuple):
                 value = (value,)
             for choice in value:
                 choice = str(choice)  # Allow for example literal numbers

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -15,6 +15,11 @@ class Form(object):
 
     attach = input
 
+    def uncheck_all(self, name):
+        for option in self.form.find_all("input", {"name": name}):
+            if "checked" in option.attrs:
+                del option.attrs["checked"]
+
     def check(self, data):
         for (name, value) in data.items():
             if not isinstance(value, list):

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -22,6 +22,12 @@ class Form(object):
 
     def check(self, data):
         for (name, value) in data.items():
+            # Complain if we don't find the name, regardless of the
+            # value
+            inputs = self.form.find_all("input", {"name": name})
+            if inputs == []:
+                raise LinkNotFoundError("No input checkbox named " + name)
+
             if not isinstance(value, list):
                 value = (value,)
             for choice in value:

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -27,6 +27,9 @@ class Form(object):
             inputs = self.form.find_all("input", {"name": name})
             if inputs == []:
                 raise LinkNotFoundError("No input checkbox named " + name)
+            type = inputs[0].attrs.get('type', 'text')
+            if type == "radio":
+                self.uncheck_all(name)
 
             if not isinstance(value, list):
                 value = (value,)

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,0 +1,12 @@
+from .browser import Browser
+
+
+class StatefulBrowser(Browser):
+    def __init__(self, session=None, soup_config=None, requests_adapters=None):
+        super(StatefulBrowser, self).__init__(
+            session, soup_config, requests_adapters)
+        self.__debug = False
+        self.__verbose = 0
+        self.__current_page = None
+        self.__current_url = None
+        self.__current_form = None

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -1,4 +1,10 @@
+from __future__ import print_function
+
+from six.moves import urllib
 from .browser import Browser
+from .utils import LinkNotFoundError
+from .form import Form
+import sys
 
 
 class StatefulBrowser(Browser):
@@ -10,3 +16,90 @@ class StatefulBrowser(Browser):
         self.__current_page = None
         self.__current_url = None
         self.__current_form = None
+
+    def set_debug(self, debug):
+        """Set the debug mode (off by default).
+
+        Set to True to enable debug mode. When active, some actions
+        will launch a browser on the current page on failure to let
+        you inspect the page content.
+        """
+        self.__debug = debug
+
+    def get_debug(self):
+        """Get the debug mode (off by default)."""
+        return self.__debug
+
+    def set_verbose(self, verbose):
+        """Set the verbosity level (an integer).
+
+        * 0 means no verbose output.
+
+        * 1 shows one dot per visited page (looks like a progress bar)
+
+        * >= 1 shows each visited URL."""
+        self.__verbose = verbose
+
+    def get_url(self):
+        """Get the URL of the currently visited page."""
+        return self.__current_url
+
+    def get_current_form(self):
+        """Get the currently selected form. See select_form()."""
+        return self.__current_form
+
+    def get_current_page(self):
+        """Get the current page as a soup object."""
+        return self.__current_page
+
+    def absolute_url(self, url):
+        """Make url absolute. url can be either relative or absolute."""
+        return urllib.parse.urljoin(self.__current_url, url)
+
+    def open(self, url, *args, **kwargs):
+        """Open the URL in this Browser object."""
+        if self.__verbose == 1:
+            sys.stdout.write('.')
+            sys.stdout.flush()
+        elif self.__verbose >= 2:
+            print(url)
+
+        resp = self.get(url, *args, **kwargs)
+        if hasattr(resp, 'soup'):
+            self.__current_page = resp.soup
+        self.__current_url = resp.url
+        self.__current_form = None
+        return resp
+
+    def select_form(self, *args, **kwargs):
+        """Select a form in the current page. Arguments are the same
+        as the select() method for a soup object."""
+        found_forms = self.__current_page.select(*args, **kwargs)
+        if len(found_forms) < 1:
+            if self.__debug:
+                print('select_form failed for', *args)
+                self.launch_browser()
+            raise LinkNotFoundError()
+
+        self.__current_form = Form(found_forms[0])
+        return self.__current_form
+
+    def submit_selected(self, btnName=None, *args, **kwargs):
+        """Submit the form selected with select_form()."""
+        if btnName is not None:
+            if 'data' not in kwargs:
+                kwargs['data'] = dict()
+            kwargs['data'][btnName] = ''
+
+        form = self.get_current_form()
+        if "action" in form.form:
+            url = self.__current_url
+        else:
+            url = self.absolute_url(form.form["action"])
+        resp = self.submit(self.__current_form,
+                           url=url,
+                           *args, **kwargs)
+        self.__current_url = resp.url
+        self.__current_page = resp.soup
+        self.__current_form = None
+        return resp

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -49,6 +49,14 @@ class StatefulBrowser(Browser):
         """Get the currently selected form. See select_form()."""
         return self.__current_form
 
+    def __setitem__(self, name, value):
+        """Call item assignment on the currently selected form."""
+        self.get_current_form()[name] = value
+
+    def new_control(self, type, name, value, **kwargs):
+        """Call new_control() on the currently selected form."""
+        return self.get_current_form().new_control(type, name, value, **kwargs)
+
     def get_current_page(self):
         """Get the current page as a soup object."""
         return self.__current_page

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -109,7 +109,8 @@ class StatefulBrowser(Browser):
                            url=url,
                            *args, **kwargs)
         self.__current_url = resp.url
-        self.__current_page = resp.soup
+        if hasattr(resp, "soup"):
+            self.__current_page = resp.soup
         self.__current_form = None
         return resp
 

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -103,3 +103,7 @@ class StatefulBrowser(Browser):
         self.__current_page = resp.soup
         self.__current_form = None
         return resp
+
+    def launch_browser(self):
+        """Launch a browser on the page, for debugging purpose."""
+        super(StatefulBrowser, self).launch_browser(self.get_current_page())

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -93,3 +93,8 @@ def test_prepare_request_file():
 
     request = browser._prepare_request(form)
     assert "multipart/form-data" in request.headers["Content-Type"]
+
+if __name__ == '__main__':
+    test_submit_online()
+    test_build_request()
+    test_prepare_request_file()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -10,7 +10,9 @@ def test_submit_online():
     input_data = {"custname": "Philip J. Fry"}
     form.input(input_data)
 
-    check_data = {"size": "medium", "topping": ["cheese", "onion"]}
+    check_data = {"size": "large", "topping": ["cheese"]}
+    form.check(check_data)
+    check_data = {"size": "medium", "topping": "onion"}
     form.check(check_data)
 
     form.textarea({"comments": "warm"})

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -31,5 +31,33 @@ def test_submit_online():
     assert data["topping"] == ["cheese", "onion"]
     assert data["comments"] == "freezer"
 
+
+def test_submit_set():
+    """Complete and submit the pizza form at http://httpbin.org/forms/post """
+    browser = mechanicalsoup.Browser()
+    page = browser.get("http://httpbin.org/forms/post")
+    form = mechanicalsoup.Form(page.soup.form)
+
+    form["custname"] = "Philip J. Fry"
+
+    form["size"] = "medium"
+    form["topping"] = ["cheese", "onion"]
+
+    form["comments"] = "freezer"
+
+    response = browser.submit(form, page.url)
+
+    # helpfully the form submits to http://httpbin.org/post which simply
+    # returns the request headers in json format
+    json = response.json()
+    data = json["form"]
+    assert data["custname"] == "Philip J. Fry"
+    assert data["custtel"] == ""  # web browser submits "" for input left blank
+    assert data["size"] == "medium"
+    assert data["topping"] == ["cheese", "onion"]
+    assert data["comments"] == "freezer"
+
+
 if __name__ == '__main__':
     test_submit_online()
+    test_submit_set()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -41,7 +41,7 @@ def test_submit_set():
     form["custname"] = "Philip J. Fry"
 
     form["size"] = "medium"
-    form["topping"] = ["cheese", "onion"]
+    form["topping"] = ("cheese", "onion")
 
     form["comments"] = "freezer"
 

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,0 +1,28 @@
+import mechanicalsoup
+
+
+def test_submit_online():
+    """Complete and submit the pizza form at http://httpbin.org/forms/post """
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open("http://httpbin.org/")
+    browser.follow_link("forms/post")
+    assert browser.get_url() == "http://httpbin.org/forms/post"
+    browser.select_form("form")
+    browser["custname"] = "Customer Name Here"
+    browser["size"] = "medium"
+    browser["topping"] = ("cheese")
+    browser["comments"] = "Some comment here"
+    browser.get_current_form().set("nosuchfield", "new value", True)
+    response = browser.submit_selected()
+    json = response.json()
+    data = json["form"]
+    assert data["custname"] == "Customer Name Here"
+    assert data["custtel"] == ""  # web browser submits "" for input left blank
+    assert data["size"] == "medium"
+    assert data["topping"] == "cheese"
+    assert data["comments"] == "Some comment here"
+    assert data["nosuchfield"] == "new value"
+
+
+if __name__ == '__main__':
+    test_submit_online()


### PR DESCRIPTION
This PR is the result of moving code from https://gitlab.com/chamilotools/chamilotools to MechanicalSoup.

The two main features are:

* StatefulBrowser, which keeps track of the current URL, page and form for you.

* The ability to write `form["name"] = value` instead of form.{check,input,textarea}.

* Because the StatefulBrowser keeps track of the current form, we can even write `browser["name"] = value` instead of `form["name"] = value`.

See what it allows in the new [example.py](https://github.com/moy/MechanicalSoup/blob/stateful-browser/example.py). The main part is

```Python
browser.open("https://github.com")
browser.follow_link("login")
browser.select_form('#login form')
browser["login"] = args.username
browser["password"] = args.password
resp = browser.submit_selected()
```

It could get better testing and documentation, but I find the current state acceptable to be merged. It can be polished in-tree later.

I'll merge this soon if I don't get any comments/objection. Don't hesitate if you think anything's wrong or if you think something could be improved.

This is a resubmission of #53 which I closed by mistake and doesn't seem to be re-openable.