### PR TITLE
Improve content of source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE README.md
+recursive-include tests *.py


### PR DESCRIPTION
Linux distributions usually source themselves from PyPI, as it is currently the case for the [Debian package](https://packages.debian.org/source/sid/python-mechanicalsoup). The source tarball is currently missing the test suite (for CI purposes), the licensing terms governing the distribution (LICENSE file) and some form of documentation (README.md file).

You might want to distribute the examples as well, if so just add a new line with `include example*.py`).