### PR TITLE
remove github formId from example.py/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ browser = mechanicalsoup.StatefulBrowser()
 
 browser.open("https://github.com")
 browser.follow_link("login")
-browser.select_form('#login form')
+browser.select_form('form')
 browser["login"] = args.username
 browser["password"] = args.password
 resp = browser.submit_selected()

--- a/example.py
+++ b/example.py
@@ -17,7 +17,7 @@ browser = mechanicalsoup.StatefulBrowser()
 
 browser.open("https://github.com")
 browser.follow_link("login")
-browser.select_form('#login form')
+browser.select_form('form')
 browser["login"] = args.username
 browser["password"] = args.password
 resp = browser.submit_selected()


### PR DESCRIPTION
running example.py raised  

```
LinkNotFoundError()    
mechanicalsoup.utils.LinkNotFoundError
```

used `"form"` instead of `"#login form"` since there is only one form in [github.com/login](https://github.com/login)