### PR TITLE
example.py: specify parser explicitly

### DIFF
--- a/example.py
+++ b/example.py
@@ -11,7 +11,7 @@ args = parser.parse_args()
 
 args.password = getpass("Please enter your GitHub password: ")
 
-browser = mechanicalsoup.StatefulBrowser()
+browser = mechanicalsoup.StatefulBrowser(soup_config={'features': 'lxml'})
 # Uncomment for a more verbose output:
 # browser.set_verbose(2)
 

--- a/example_manual.py
+++ b/example_manual.py
@@ -9,7 +9,7 @@ parser.add_argument("username")
 parser.add_argument("password")
 args = parser.parse_args()
 
-browser = mechanicalsoup.Browser()
+browser = mechanicalsoup.Browser(soup_config={'features': 'lxml'})
 
 # request github login page. the result is a requests.Response object
 # http://docs.python-requests.org/en/latest/user/quickstart/#response-content


### PR DESCRIPTION
It's really bad practice to let the system decide which parser to use:
it encourages people to write scripts that will behave differently on
different machines, depending on which parser is installed.

example.py does work with lxml, but not with html.parser for example,
hence the example is broken on machines where html.parser is available
but lxml is not.

Fix this by specifying the parser explicitly.

IMHO, this is the proper fix to the issue raised by PR #67.