### PR TITLE
Instructions on how to setup virtualenv for both Python2 & Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Development
 
 [![Build Status](https://travis-ci.org/hickford/MechanicalSoup.svg?branch=master)](https://travis-ci.org/hickford/MechanicalSoup)
 
-You can develop against multiple versions of Python using virtualenv:
+You can develop against multiple versions of Python using [virtualenv](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments):
 
     python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
     pip install pytest flake8 requests_mock

--- a/README.md
+++ b/README.md
@@ -91,9 +91,27 @@ Development
 
 [![Build Status](https://travis-ci.org/hickford/MechanicalSoup.svg?branch=master)](https://travis-ci.org/hickford/MechanicalSoup)
 
-### Tests
+You can develop against multiple versions of Python using virtualenv:
 
-    py.test
+    python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
+    pip install pytest flake8 requests_mock
+and
+
+    virtualenv -p python2 --no-site-packages .virtual-py2 && source .virtual-py2/bin/activate
+    pip install pytest flake8 requests_mock
+
+After making changes, check syntax:
+
+    flake8 $(git ls-files mechanicalsoup/'*.py') example.py
+
+Then run py.test in all virtualenvs:
+
+    source .virtual-py3/bin/activate
+    python setup.py install && pytest
+
+    source .virtual-py2/bin/activate
+    python setup.py install && pytest
+
 
 ### Roadmap
 


### PR DESCRIPTION
I found the https://github.com/hickford/MechanicalSoup#development section a bit sparse.
If you've got a 'dev' version of mechanicalsoup and a system installed one that is maybe being used by other projects, it's not clear how to test the dev version separately, or how to test against multiple versions of Python.  Also, running `py.test` inside a .virtualenv didn't work for me as that looks at the system wide version I think.