### PR TITLE
Apply user_agent to all session requests

### DIFF
--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -51,7 +51,13 @@ def test_404():
     resp = browser.open("http://httpbin.org/")
     assert resp.status_code == 200
 
+def test_user_agent():
+    browser = mechanicalsoup.StatefulBrowser(user_agent='007')
+    resp = browser.open("http://httpbin.org/user-agent")
+    assert resp.json() == {'user-agent': '007'}
+
 if __name__ == '__main__':
     test_submit_online()
     test_no_404()
     test_404()
+    test_user_agent()


### PR DESCRIPTION
The previous implementation of user_agent only set the user_agent
for requests created with `Browser._build_request`. However, there
are many other methods in `Browser` that make requests, and these
did not use the specified user_agent.

The `test_user_agent` function is added to show the failure
scenario. To fix this, we set user_agent for the session owned by
`Browser`, so that all requests use the specified user_agent.