### PR TITLE
.gitignore: ignore virtualenv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# virtualenv
+.virtual-*


### PR DESCRIPTION
These are created as byproducts of the recommended
development workflow.