### PR TITLE
Fix methods that choose between multiple submit elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 install:
   - python setup.py install
   - pip install flake8 requests_mock
+  - pip install --upgrade pytest
 script:
   - |
     if ! python --version 2>&1 | grep -q -e 'Python 2.6'

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -109,6 +109,9 @@ class Form(object):
         return control
 
     def choose_submit(self, el):
+        '''Selects the submit input (or button) element specified by 'el',
+        where 'el' can be either a bs4.element.Tag or just its name attribute.
+        If the element is not found, raise a LinkNotFoundError exception.'''
         # In a normal web browser, when a input[type=submit] is clicked,
         # all other submits aren't sent. You can use simulate this as
         # following:
@@ -130,4 +133,7 @@ class Form(object):
 
             del inp['name']
 
-        return found
+        if not found:
+            raise LinkNotFoundError(
+                "Specified submit element not found: {}".format(el)
+            )

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -125,9 +125,9 @@ class Form(object):
         inps = self.form.select('input[type="submit"], button[type="submit"]')
         for inp in inps:
             if inp == el or inp['name'] == el:
+                found = True
                 continue
 
             del inp['name']
-            found = True
 
         return found

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -111,7 +111,8 @@ class Form(object):
     def choose_submit(self, el):
         '''Selects the submit input (or button) element specified by 'el',
         where 'el' can be either a bs4.element.Tag or just its name attribute.
-        If the element is not found, raise a LinkNotFoundError exception.'''
+        If the element is not found or if multiple elements match, raise a
+        LinkNotFoundError exception.'''
         # In a normal web browser, when a input[type=submit] is clicked,
         # all other submits aren't sent. You can use simulate this as
         # following:
@@ -128,6 +129,10 @@ class Form(object):
         inps = self.form.select('input[type="submit"], button[type="submit"]')
         for inp in inps:
             if inp == el or inp['name'] == el:
+                if found:
+                    raise LinkNotFoundError(
+                        "Multiple submit elements match: {}".format(el)
+                    )
                 found = True
                 continue
 

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -131,7 +131,7 @@ class Form(object):
             if inp == el or inp['name'] == el:
                 if found:
                     raise LinkNotFoundError(
-                        "Multiple submit elements match: {}".format(el)
+                        "Multiple submit elements match: {0}".format(el)
                     )
                 found = True
                 continue
@@ -140,5 +140,5 @@ class Form(object):
 
         if not found:
             raise LinkNotFoundError(
-                "Specified submit element not found: {}".format(el)
+                "Specified submit element not found: {0}".format(el)
             )

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -110,11 +110,10 @@ class StatefulBrowser(Browser):
         return self.__current_form
 
     def submit_selected(self, btnName=None, *args, **kwargs):
-        """Submit the form selected with select_form()."""
+        """Submit the form selected with select_form(). If there are multiple
+        submit input/button elements, use 'btnName' to choose between them."""
         if btnName is not None:
-            if 'data' not in kwargs:
-                kwargs['data'] = dict()
-            kwargs['data'][btnName] = ''
+            self.get_current_form().choose_submit(btnName)
 
         resp = self.submit(self.__current_form,
                            url=self.__current_url,

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,8 +1,9 @@
 import mechanicalsoup
+import sys
 from bs4 import BeautifulSoup
 import tempfile
 from requests.cookies import RequestsCookieJar
-
+import pytest
 
 def test_submit_online():
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
@@ -135,3 +136,6 @@ def test_get_cookiejar():
     jar = browser.get_cookiejar()
     assert jar.get('k1') == 'v1'
     assert jar.get('k2') == 'v2'
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -135,12 +135,3 @@ def test_get_cookiejar():
     jar = browser.get_cookiejar()
     assert jar.get('k1') == 'v1'
     assert jar.get('k2') == 'v2'
-
-if __name__ == '__main__':
-    test_submit_online()
-    test_build_request()
-    test_prepare_request_file()
-    test_no_404()
-    test_404()
-    test_set_cookiejar()
-    test_get_cookiejar()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,4 +1,5 @@
 import mechanicalsoup
+import sys
 import requests_mock
 import pytest
 try:
@@ -209,3 +210,6 @@ def test_form_action():
     browser['text1'] = 'newText1'
     res = browser.submit_selected()
     assert(res.status_code == 200 and browser.get_url() == url)
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -153,6 +153,23 @@ def test_choose_submit_fail(select_name):
         form.choose_submit(select_name['name'])
 
 
+choose_submit_multiple_match_form = '''
+<html>
+  <form id="choose-submit-form">
+    <input type="submit" name="test_submit" value="First Submit" />
+    <input type="submit" name="test_submit" value="Second Submit" />
+  </form>
+</html>
+'''
+
+def test_choose_submit_multiple_match():
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(choose_submit_multiple_match_form)
+    form = browser.select_form('#choose-submit-form')
+    with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+        form.choose_submit('test_submit')
+
+
 submit_form_noaction = '''
 <html>
   <body>

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -131,6 +131,26 @@ def test_choose_submit(expected_post):
     assert(res.status_code == 200 and res.text == 'Success!')
 
 
+choose_submit_fail_form = '''
+<html>
+  <form id="choose-submit-form">
+    <input type="submit" name="test_submit" value="Test Submit" />
+  </form>
+</html>
+'''
+
+@pytest.mark.parametrize("select_name", [
+    pytest.param({'name': 'does_not_exist', 'result': False}, id='not found'),
+    pytest.param({'name': 'test_submit', 'result': True}, id='found'),
+])
+def test_choose_submit_fail(select_name):
+    browser = mechanicalsoup.StatefulBrowser()
+    browser.open_fake_page(choose_submit_fail_form)
+    form = browser.select_form('#choose-submit-form')
+    found = form.choose_submit(select_name['name'])
+    assert(found == select_name['result'])
+
+
 submit_form_noaction = '''
 <html>
   <body>

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -102,6 +102,12 @@ def setup_mock_browser(expected_post=None):
 @pytest.mark.parametrize("expected_post", [
     pytest.param(
         [
+            ('comment', 'Testing preview page'),
+            ('preview', 'Preview Page'),
+            ('text', 'Setting some text!')
+        ], id='preview'),
+    pytest.param(
+        [
             ('comment', 'Created new page'),
             ('save', 'Submit changes'),
             ('text', '= Heading =\n\nNew page here!\n')

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -125,8 +125,7 @@ def test_choose_submit(expected_post):
     form = browser.select_form('#choose-submit-form')
     browser['text'] = expected_post[2][1]
     browser['comment'] = expected_post[0][1]
-    found = form.choose_submit(expected_post[1][0])
-    assert(found)
+    form.choose_submit(expected_post[1][0])
     res = browser.submit_selected()
     assert(res.status_code == 200 and res.text == 'Success!')
 
@@ -140,15 +139,18 @@ choose_submit_fail_form = '''
 '''
 
 @pytest.mark.parametrize("select_name", [
-    pytest.param({'name': 'does_not_exist', 'result': False}, id='not found'),
-    pytest.param({'name': 'test_submit', 'result': True}, id='found'),
+    pytest.param({'name': 'does_not_exist', 'fails': True}, id='not found'),
+    pytest.param({'name': 'test_submit', 'fails': False}, id='found'),
 ])
 def test_choose_submit_fail(select_name):
     browser = mechanicalsoup.StatefulBrowser()
     browser.open_fake_page(choose_submit_fail_form)
     form = browser.select_form('#choose-submit-form')
-    found = form.choose_submit(select_name['name'])
-    assert(found == select_name['result'])
+    if select_name['fails']:
+        with pytest.raises(mechanicalsoup.utils.LinkNotFoundError):
+            form.choose_submit(select_name['name'])
+    else:
+        form.choose_submit(select_name['name'])
 
 
 submit_form_noaction = '''

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -171,10 +171,3 @@ def test_form_action():
     browser['text1'] = 'newText1'
     res = browser.submit_selected()
     assert(res.status_code == 200 and browser.get_url() == url)
-
-if __name__ == '__main__':
-    test_submit_online()
-    test_submit_set()
-    test_choose_submit()
-    test_form_noaction()
-    test_form_action()

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,7 +1,8 @@
 import mechanicalsoup
 import re
 from bs4 import BeautifulSoup
-
+from test_form import setup_mock_browser
+import pytest
 
 def test_submit_online():
     """Complete and submit the pizza form at http://httpbin.org/forms/post """
@@ -98,3 +99,28 @@ def test_links():
     two_links = browser.links(id=re.compile('_link'))
     assert len(two_links) == 2
     assert two_links == BeautifulSoup(html).find_all('a')
+
+
+@pytest.mark.parametrize("expected_post", [
+    pytest.param(
+        [
+            ('comment', 'Selecting an input submit'),
+            ('diff', 'Review Changes'),
+            ('text', 'Setting some text!')
+        ], id='input'),
+    pytest.param(
+        [
+            ('comment', 'Selecting a button submit'),
+            ('cancel', 'Cancel'),
+            ('text', '= Heading =\n\nNew page here!\n')
+        ], id='button'),
+])
+def test_submit_btnName(expected_post):
+    '''Tests that the btnName argument chooses the submit button.'''
+    browser, url = setup_mock_browser(expected_post=expected_post)
+    browser.open(url)
+    form = browser.select_form('#choose-submit-form')
+    browser['text'] = expected_post[2][1]
+    browser['comment'] = expected_post[0][1]
+    res = browser.submit_selected(btnName = expected_post[1][0])
+    assert(res.status_code == 200 and res.text == 'Success!')

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -1,4 +1,5 @@
 import mechanicalsoup
+import sys
 import re
 from bs4 import BeautifulSoup
 from test_form import setup_mock_browser
@@ -124,3 +125,6 @@ def test_submit_btnName(expected_post):
     browser['comment'] = expected_post[0][1]
     res = browser.submit_selected(btnName = expected_post[1][0])
     assert(res.status_code == 200 and res.text == 'Success!')
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)

--- a/tests/test_stateful_browser.py
+++ b/tests/test_stateful_browser.py
@@ -98,11 +98,3 @@ def test_links():
     two_links = browser.links(id=re.compile('_link'))
     assert len(two_links) == 2
     assert two_links == BeautifulSoup(html).find_all('a')
-
-if __name__ == '__main__':
-    test_submit_online()
-    test_no_404()
-    test_404()
-    test_user_agent()
-    test_open_relative()
-    test_links()


### PR DESCRIPTION
`Form.choose_submit`:
* Fix the logic that decides when a submit element matches the input argument. The matching was done correctly, but the bookkeeping about the match was not.
* Improve safety by replacing the boolean return value with a raised `LinkNotFoundError` exception unless exactly one match is found.

`StatefulBrowser.submit_selected`:
* Fix the `btnName` argument so that the POST data is correctly generated in the case where the form has multiple submit elements.

See commit messages and issue #92 for more details.

Minor changes:
* Add or improve method docstrings.
* Remove manual (non-`pytest`) infrastructure for running tests due to the addition of `pytest` features.
* Additional test cases and code de-duplication of `test_choose_submit`.