### PR TITLE
Add code coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+include =
+    # The tested code will be located wherever the module was installed.
+    */mechanicalsoup/*.py
+
+omit =
+    */__version__.py
+    */__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - python setup.py install
   - pip install flake8 requests_mock
   - pip install --upgrade pytest
+  - pip install pytest-cov
 script:
   - |
     if ! python --version 2>&1 | grep -q -e 'Python 2.6'
@@ -20,3 +21,5 @@ script:
         flake8 $(git ls-files mechanicalsoup/'*.py') example.py
     fi
   - py.test
+after_success:
+  - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'

--- a/README.md
+++ b/README.md
@@ -91,15 +91,16 @@ Development
 ---------
 
 [![Build Status](https://travis-ci.org/hickford/MechanicalSoup.svg?branch=master)](https://travis-ci.org/hickford/MechanicalSoup)
+[![Coverage Status](https://codecov.io/gh/hickford/MechanicalSoup/branch/master/graph/badge.svg)](https://codecov.io/gh/hickford/MechanicalSoup)
 
 You can develop against multiple versions of Python using [virtualenv](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments):
 
     python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
-    pip install pytest flake8 requests_mock
+    pip install pytest pytest-cov flake8 requests_mock
 and
 
     virtualenv -p python2 --no-site-packages .virtual-py2 && source .virtual-py2/bin/activate
-    pip install pytest flake8 requests_mock
+    pip install pytest pytest-cov flake8 requests_mock
 
 After making changes, check syntax:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[tool:pytest]
+# These options allow us to invoke an undecorated pytest to run tests.
+addopts = --cov --cov-config .coveragerc


### PR DESCRIPTION
Use the pytest-cov plugin to do coverage reporting. Running tests
locally with `pytest` will output the report. In the Travis-CI builds,
this report will automatically be uploaded to codecov.io.

Closes #88.

I believe that @hickford will need to create a codecov.io account to set up the integration with Travis-CI and to enable the codecov badge in the README. I know that he already has a coveralls account, but I think codecov.io is the better choice.

See the [codecov.io page for my fork](https://codecov.io/gh/hemberger/MechanicalSoup/tree/85c484d1c2e6513ce67fd25053b37bae6da7c7d0) to see the effects of this PR.