### PR TITLE
Drop unsupported Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4
@@ -15,11 +14,7 @@ install:
   - pip install --upgrade pytest
   - pip install pytest-cov
 script:
-  - |
-    if ! python --version 2>&1 | grep -q -e 'Python 2.6'
-    then
-        flake8 $(git ls-files mechanicalsoup/'*.py') example.py
-    fi
+  - flake8 $(git ls-files mechanicalsoup/'*.py') example.py
   - py.test
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ From [PyPI](https://pypi.python.org/pypi/MechanicalSoup/)
 
      pip install MechanicalSoup
 
-Python versions 2.7, 3.3-3.6, PyPy and PyPy3 are supported (and tested against).
+Python versions 2.7, 3.4-3.6, PyPy and PyPy3 are supported (and tested against).
 
 Example
 ------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ From [PyPI](https://pypi.python.org/pypi/MechanicalSoup/)
 
      pip install MechanicalSoup
 
-Python versions 2.6-2.7, 3.3-3.6, PyPy and PyPy3 are supported (and tested against).
+Python versions 2.7, 3.3-3.6, PyPy and PyPy3 are supported (and tested against).
 
 Example
 ------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
Python 2.6 has been at end-of-life as of 2013-10-29, and 3.3 has one day left, until 2017-09-29.

https://snarky.ca/stop-using-python-2-6/