### PR TITLE
Run flake8 with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ python:
   - pypy
   - pypy3
 install:
-  - pip install flake8
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
 script:
-  - flake8 $(git ls-files mechanicalsoup/'*.py') example.py
   - python setup.py test
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'

--- a/README.md
+++ b/README.md
@@ -97,17 +97,13 @@ Development
 You can develop against multiple versions of Python using [virtualenv](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments):
 
     python3 -m venv .virtual-py3 && source .virtual-py3/bin/activate
-    pip install pytest pytest-cov flake8 requests_mock
+    pip install pytest pytest-cov pytest-flake8 requests_mock
 and
 
     virtualenv -p python2 --no-site-packages .virtual-py2 && source .virtual-py2/bin/activate
-    pip install pytest pytest-cov flake8 requests_mock
+    pip install pytest pytest-cov pytest-flake8 requests_mock
 
-After making changes, check syntax:
-
-    flake8 $(git ls-files mechanicalsoup/'*.py') example.py
-
-Then run py.test in all virtualenvs:
+After making changes, run pytest in all virtualenvs:
 
     source .virtual-py3/bin/activate
     python setup.py install && pytest

--- a/mechanicalsoup/form.py
+++ b/mechanicalsoup/form.py
@@ -49,7 +49,7 @@ class Form(object):
                     raise LinkNotFoundError(
                         "No input checkbox named %s with choice %s" %
                         (name, choice)
-                        )
+                    )
 
     def textarea(self, data):
         for (name, value) in data.items():

--- a/mechanicalsoup/stateful_browser.py
+++ b/mechanicalsoup/stateful_browser.py
@@ -88,7 +88,7 @@ class StatefulBrowser(Browser):
         is url. Useful mainly for testing."""
         soup_config = soup_config or dict()
         self.__current_page = bs4.BeautifulSoup(
-                page_text, **soup_config)
+            page_text, **soup_config)
         self.__current_url = url
         self.__current_form = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,11 @@ universal=1
 
 [tool:pytest]
 # These options allow us to invoke an undecorated pytest to run tests.
-addopts = --cov --cov-config .coveragerc
+addopts = --cov --cov-config .coveragerc --flake8
+
+# Specify which files to ignore for flake8 tests (note that there is no file
+# inclusion option, only exclusion).
+flake8-ignore =
+    setup.py ALL
+    tests/*.py ALL
+    docs/*.py ALL

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     tests_require=[
         'pytest',
         'pytest-cov',
+        'pytest-flake8',
         'requests_mock'
     ]
 )


### PR DESCRIPTION
We can avoid the manual step of running flake8 by integrating it
into the test suite with the pytest-flake8 plugin.

This PR also fixes a few flake8 warnings.