### PR TITLE
Fix Travis-CI coverage report uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 install:
   - pip install flake8
   - pip install --upgrade pytest # needed for cases where there is already an old pytest installed
+  - pip install pytest-cov       # needed for the codecov uploader
 script:
   - flake8 $(git ls-files mechanicalsoup/'*.py') example.py
   - python setup.py test


### PR DESCRIPTION
The `coverage` executable needs to exist in the environment for the
Codecov uploader to work correctly. Therefore, it is insufficient to
install `pytest-cov` (which provides `coverage`) with `tests_require`
in setup.py.

This fixes the "Python coveragepy not found" error output by the
uploader after the change to the Travis-CI environment in b3232dd.